### PR TITLE
Fix variable name typo

### DIFF
--- a/lessons/Arrow scope/background.md
+++ b/lessons/Arrow scope/background.md
@@ -35,7 +35,7 @@ We get the `TypeError` because the anonymous function we passed to the setTimeou
 	function sayHello(){
 		var _this = this;
 		
-		this.name = 'hendrik';
+		_this.name = 'hendrik';
 		
 		setTimeout(function(){
 			console.log('hello ' + _this.name);


### PR DESCRIPTION
This example should use the newly created `_this` variable to illustrate how to overcome the scope gotchas.
